### PR TITLE
Update loadFolders.xml

### DIFF
--- a/loadFolders.xml
+++ b/loadFolders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <loadFolders>
 	<v1.4>
-		<li>Content</li>
+		<li>ModPatches/li>
 		<li IfModActive="vanillaexpanded.vaed">Mods/vanillaexpanded.vaed</li>
 	</v1.4>
 </loadFolders>


### PR DESCRIPTION
changed content to be named Dogutility/ModPatches/Mods/vanillaexpanded.vaed (only mod patch that will be made) if people want Erins dog mod to be included they need to provide textures since I don't use the mod myself. Don't forget to add a folder called ModPatches/Mods/vanillaexpanded.vaed (placeholder textures of the dogs so the folder is created