### PR TITLE
Update .markdownlint.yaml

### DIFF
--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,10 +1,10 @@
 # Autoformatter friendly markdownlint config (all formatting rules disabled)
 default: true
-blank_lines: false
+blank_lines: true
 bullet: false
-html: false
-indentation: false
+html: true
+indentation: true
 line_length: false
 spaces: false
-url: false
-whitespace: false
+url: true
+whitespace: true


### PR DESCRIPTION
Edited the settings to use blank line at the end and allowed to use html links in my readme.md for markdown lint settings.